### PR TITLE
スケジュール管理機能 バックエンドAPI実装

### DIFF
--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Models\Schedule;
 use App\Models\CalendarDate;
+use App\Http\Requests\StoreScheduleRequest;
+use App\Http\Requests\UpdateScheduleRequest;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Carbon\Carbon;
@@ -46,19 +48,9 @@ class ScheduleController extends Controller
         ]);
     }
 
-    public function store(Request $request): JsonResponse
+    public function store(StoreScheduleRequest $request): JsonResponse
     {
-        $validated = $request->validate([
-            'date_id' => 'required|exists:calendar_dates,id',
-            'title' => 'required|string|max:255',
-            'description' => 'nullable|string',
-            'start_time' => 'nullable|date_format:H:i',
-            'end_time' => 'nullable|date_format:H:i|after:start_time',
-            'schedule_type_id' => 'required|exists:schedule_types,id',
-            'resident_id' => 'nullable|exists:residents,id',
-        ]);
-
-        $schedule = Schedule::create($validated);
+        $schedule = Schedule::create($request->validated());
         $schedule->load(['calendarDate', 'scheduleType', 'resident']);
 
         return response()->json([
@@ -78,19 +70,9 @@ class ScheduleController extends Controller
         ]);
     }
 
-    public function update(Request $request, Schedule $schedule): JsonResponse
+    public function update(UpdateScheduleRequest $request, Schedule $schedule): JsonResponse
     {
-        $validated = $request->validate([
-            'date_id' => 'sometimes|exists:calendar_dates,id',
-            'title' => 'sometimes|string|max:255',
-            'description' => 'nullable|string',
-            'start_time' => 'nullable|date_format:H:i',
-            'end_time' => 'nullable|date_format:H:i|after:start_time',
-            'schedule_type_id' => 'sometimes|exists:schedule_types,id',
-            'resident_id' => 'nullable|exists:residents,id',
-        ]);
-
-        $schedule->update($validated);
+        $schedule->update($request->validated());
         $schedule->load(['calendarDate', 'scheduleType', 'resident']);
 
         return response()->json([

--- a/app/Http/Controllers/ScheduleController.php
+++ b/app/Http/Controllers/ScheduleController.php
@@ -3,63 +3,120 @@
 namespace App\Http\Controllers;
 
 use App\Models\Schedule;
+use App\Models\CalendarDate;
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Carbon\Carbon;
 
 class ScheduleController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
+    public function index(Request $request): JsonResponse
     {
-        //
+        $query = Schedule::withRelations();
+
+        if ($request->has('date')) {
+            $query->forDate($request->date);
+        }
+
+        if ($request->has('start_date') && $request->has('end_date')) {
+            $query->forDateRange($request->start_date, $request->end_date);
+        }
+
+        $schedules = $query->orderBy('start_time')->get();
+
+        return response()->json([
+            'status' => 'success',
+            'data' => $schedules
+        ]);
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
+    public function getMonthlySchedules(Request $request): JsonResponse
+    {
+        $year = $request->input('year', now()->year);
+        $month = $request->input('month', now()->month);
+
+        $calendarDates = CalendarDate::forMonth($year, $month)
+            ->withSchedules()
+            ->orderBy('calendar_date')
+            ->get();
+
+        return response()->json([
+            'status' => 'success',
+            'data' => $calendarDates
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'date_id' => 'required|exists:calendar_dates,id',
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'start_time' => 'nullable|date_format:H:i',
+            'end_time' => 'nullable|date_format:H:i|after:start_time',
+            'schedule_type_id' => 'required|exists:schedule_types,id',
+            'resident_id' => 'nullable|exists:residents,id',
+        ]);
+
+        $schedule = Schedule::create($validated);
+        $schedule->load(['calendarDate', 'scheduleType', 'resident']);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'スケジュールが作成されました',
+            'data' => $schedule
+        ], 201);
+    }
+
+    public function show(Schedule $schedule): JsonResponse
+    {
+        $schedule->load(['calendarDate', 'scheduleType', 'resident']);
+
+        return response()->json([
+            'status' => 'success',
+            'data' => $schedule
+        ]);
+    }
+
+    public function update(Request $request, Schedule $schedule): JsonResponse
+    {
+        $validated = $request->validate([
+            'date_id' => 'sometimes|exists:calendar_dates,id',
+            'title' => 'sometimes|string|max:255',
+            'description' => 'nullable|string',
+            'start_time' => 'nullable|date_format:H:i',
+            'end_time' => 'nullable|date_format:H:i|after:start_time',
+            'schedule_type_id' => 'sometimes|exists:schedule_types,id',
+            'resident_id' => 'nullable|exists:residents,id',
+        ]);
+
+        $schedule->update($validated);
+        $schedule->load(['calendarDate', 'scheduleType', 'resident']);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'スケジュールが更新されました',
+            'data' => $schedule
+        ]);
+    }
+
+    public function destroy(Schedule $schedule): JsonResponse
+    {
+        $schedule->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'スケジュールが削除されました'
+        ]);
+    }
+
     public function create()
     {
-        //
+        return redirect('/calendar');
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(Schedule $schedule)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
     public function edit(Schedule $schedule)
     {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, Schedule $schedule)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(Schedule $schedule)
-    {
-        //
+        return redirect('/calendar');
     }
 }

--- a/app/Http/Controllers/ScheduleTypeController.php
+++ b/app/Http/Controllers/ScheduleTypeController.php
@@ -4,62 +4,84 @@ namespace App\Http\Controllers;
 
 use App\Models\ScheduleType;
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 
 class ScheduleTypeController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
+    public function index(): JsonResponse
     {
-        //
+        $scheduleTypes = ScheduleType::all();
+
+        return response()->json([
+            'status' => 'success',
+            'data' => $scheduleTypes
+        ]);
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'type_name' => 'required|string|max:255|unique:schedule_types',
+            'color_code' => 'required|string|size:7|regex:/^#[0-9A-Fa-f]{6}$/',
+        ]);
+
+        $scheduleType = ScheduleType::create($validated);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'スケジュールタイプが作成されました',
+            'data' => $scheduleType
+        ], 201);
+    }
+
+    public function show(ScheduleType $scheduleType): JsonResponse
+    {
+        return response()->json([
+            'status' => 'success',
+            'data' => $scheduleType
+        ]);
+    }
+
+    public function update(Request $request, ScheduleType $scheduleType): JsonResponse
+    {
+        $validated = $request->validate([
+            'type_name' => 'sometimes|string|max:255|unique:schedule_types,type_name,' . $scheduleType->id,
+            'color_code' => 'sometimes|string|size:7|regex:/^#[0-9A-Fa-f]{6}$/',
+        ]);
+
+        $scheduleType->update($validated);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'スケジュールタイプが更新されました',
+            'data' => $scheduleType
+        ]);
+    }
+
+    public function destroy(ScheduleType $scheduleType): JsonResponse
+    {
+        if ($scheduleType->schedules()->exists()) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'このスケジュールタイプは使用中のため削除できません'
+            ], 422);
+        }
+
+        $scheduleType->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'スケジュールタイプが削除されました'
+        ]);
+    }
+
     public function create()
     {
-        //
+        return redirect('/calendar');
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(ScheduleType $scheduleType)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
     public function edit(ScheduleType $scheduleType)
     {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, ScheduleType $scheduleType)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(ScheduleType $scheduleType)
-    {
-        //
+        return redirect('/calendar');
     }
 }

--- a/app/Http/Requests/StoreScheduleRequest.php
+++ b/app/Http/Requests/StoreScheduleRequest.php
@@ -11,7 +11,7 @@ class StoreScheduleRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**

--- a/app/Http/Requests/StoreScheduleRequest.php
+++ b/app/Http/Requests/StoreScheduleRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreScheduleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/StoreScheduleRequest.php
+++ b/app/Http/Requests/StoreScheduleRequest.php
@@ -72,12 +72,18 @@ class StoreScheduleRequest extends FormRequest
         return Schedule::where('date_id', $this->date_id)
             ->where('resident_id', $this->resident_id)
             ->where(function ($query) {
-                $query->whereBetween('start_time', [$this->start_time, $this->end_time])
-                      ->orWhereBetween('end_time', [$this->start_time, $this->end_time])
-                      ->orWhere(function ($q) {
-                          $q->where('start_time', '<=', $this->start_time)
-                            ->where('end_time', '>=', $this->end_time);
-                      });
+                $query->where(function ($q) {
+                    $q->whereBetween('start_time', [$this->start_time, $this->end_time])
+                      ->orWhereBetween('end_time', [$this->start_time, $this->end_time]);
+                })
+                ->orWhere(function ($q) {
+                    $q->where('start_time', '<=', $this->start_time)
+                      ->where('end_time', '>=', $this->end_time);
+                })
+                ->orWhere(function ($q) {
+                    $q->where('start_time', '>=', $this->start_time)
+                      ->where('end_time', '<=', $this->end_time);
+                });
             })
             ->exists();
     }

--- a/app/Http/Requests/StoreScheduleRequest.php
+++ b/app/Http/Requests/StoreScheduleRequest.php
@@ -73,14 +73,22 @@ class StoreScheduleRequest extends FormRequest
             ->where('resident_id', $this->resident_id)
             ->where(function ($query) {
                 $query->where(function ($q) {
-                    $q->whereBetween('start_time', [$this->start_time, $this->end_time])
-                      ->orWhereBetween('end_time', [$this->start_time, $this->end_time]);
+                    // 既存スケジュールの開始時刻が新規の時間範囲内（境界除く）
+                    $q->where('start_time', '>', $this->start_time)
+                      ->where('start_time', '<', $this->end_time);
                 })
                 ->orWhere(function ($q) {
+                    // 既存スケジュールの終了時刻が新規の時間範囲内（境界除く）
+                    $q->where('end_time', '>', $this->start_time)
+                      ->where('end_time', '<', $this->end_time);
+                })
+                ->orWhere(function ($q) {
+                    // 既存スケジュールが新規スケジュールを完全に包含
                     $q->where('start_time', '<=', $this->start_time)
                       ->where('end_time', '>=', $this->end_time);
                 })
                 ->orWhere(function ($q) {
+                    // 新規スケジュールが既存スケジュールを完全に包含
                     $q->where('start_time', '>=', $this->start_time)
                       ->where('end_time', '<=', $this->end_time);
                 });

--- a/app/Http/Requests/StoreScheduleRequest.php
+++ b/app/Http/Requests/StoreScheduleRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use App\Models\Schedule;
 
 class StoreScheduleRequest extends FormRequest
 {
@@ -30,5 +32,33 @@ class StoreScheduleRequest extends FormRequest
             'schedule_type_id' => ['required', 'exists:schedule_types,id'],
             'resident_id' => ['required', 'exists:residents,id'],
         ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            if ($this->hasTimeConflict()) {
+                $validator->errors()->add('time_conflict', '指定された時間帯に既にスケジュールが存在します。');
+            }
+        });
+    }
+
+    private function hasTimeConflict(): bool
+    {
+        if (!$this->filled(['date_id', 'start_time', 'end_time', 'resident_id'])) {
+            return false;
+        }
+
+        return Schedule::where('date_id', $this->date_id)
+            ->where('resident_id', $this->resident_id)
+            ->where(function ($query) {
+                $query->whereBetween('start_time', [$this->start_time, $this->end_time])
+                      ->orWhereBetween('end_time', [$this->start_time, $this->end_time])
+                      ->orWhere(function ($q) {
+                          $q->where('start_time', '<=', $this->start_time)
+                            ->where('end_time', '>=', $this->end_time);
+                      });
+            })
+            ->exists();
     }
 }

--- a/app/Http/Requests/StoreScheduleRequest.php
+++ b/app/Http/Requests/StoreScheduleRequest.php
@@ -22,7 +22,13 @@ class StoreScheduleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'date_id' => ['required', 'exists:calendar_dates,id'],
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'start_time' => ['required', 'date_format:H:i'],
+            'end_time' => ['required', 'date_format:H:i', 'after:start_time'],
+            'schedule_type_id' => ['required', 'exists:schedule_types,id'],
+            'resident_id' => ['required', 'exists:residents,id'],
         ];
     }
 }

--- a/app/Http/Requests/StoreScheduleRequest.php
+++ b/app/Http/Requests/StoreScheduleRequest.php
@@ -89,8 +89,8 @@ class StoreScheduleRequest extends FormRequest
                 })
                 ->orWhere(function ($q) {
                     // 新規スケジュールが既存スケジュールを完全に包含
-                    $q->where('start_time', '>=', $this->start_time)
-                      ->where('end_time', '<=', $this->end_time);
+                    $q->where('start_time', '>', $this->start_time)
+                      ->where('end_time', '<', $this->end_time);
                 });
             })
             ->exists();

--- a/app/Http/Requests/StoreScheduleRequest.php
+++ b/app/Http/Requests/StoreScheduleRequest.php
@@ -34,6 +34,26 @@ class StoreScheduleRequest extends FormRequest
         ];
     }
 
+    public function messages(): array
+    {
+        return [
+            'date_id.required' => '日付を選択してください。',
+            'date_id.exists' => '有効な日付を選択してください。',
+            'title.required' => 'タイトルを入力してください。',
+            'title.max' => 'タイトルは255文字以内で入力してください。',
+            'description.max' => '説明は1000文字以内で入力してください。',
+            'start_time.required' => '開始時刻を入力してください。',
+            'start_time.date_format' => '開始時刻は時:00の形式で入力してください。',
+            'end_time.required' => '終了時刻を入力してください。',
+            'end_time.date_format' => '終了時刻は時:00の形式で入力してください。',
+            'end_time.after' => '終了時刻は開始時刻より後に設定してください。',
+            'schedule_type_id.required' => 'スケジュールタイプを選択してください。',
+            'schedule_type_id.exists' => '有効なスケジュールタイプを選択してください。',
+            'resident_id.required' => '入居者を選択してください。',
+            'resident_id.exists' => '有効な入居者を選択してください。',
+        ];
+    }
+
     public function withValidator($validator)
     {
         $validator->after(function ($validator) {

--- a/app/Http/Requests/UpdateScheduleRequest.php
+++ b/app/Http/Requests/UpdateScheduleRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateScheduleRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateScheduleRequest.php
+++ b/app/Http/Requests/UpdateScheduleRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use App\Models\Schedule;
 
 class UpdateScheduleRequest extends FormRequest
 {
@@ -30,5 +32,40 @@ class UpdateScheduleRequest extends FormRequest
             'schedule_type_id' => ['sometimes', 'exists:schedule_types,id'],
             'resident_id' => ['sometimes', 'exists:residents,id'],
         ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            if ($this->hasTimeConflict()) {
+                $validator->errors()->add('time_conflict', '指定された時間帯に既にスケジュールが存在します。');
+            }
+        });
+    }
+
+    private function hasTimeConflict(): bool
+    {
+        $schedule = $this->route('schedule');
+        if (!$schedule) {
+            return false;
+        }
+
+        $dateId = $this->filled('date_id') ? $this->date_id : $schedule->date_id;
+        $residentId = $this->filled('resident_id') ? $this->resident_id : $schedule->resident_id;
+        $startTime = $this->filled('start_time') ? $this->start_time : $schedule->start_time;
+        $endTime = $this->filled('end_time') ? $this->end_time : $schedule->end_time;
+
+        return Schedule::where('date_id', $dateId)
+            ->where('resident_id', $residentId)
+            ->where('id', '!=', $schedule->id)
+            ->where(function ($query) use ($startTime, $endTime) {
+                $query->whereBetween('start_time', [$startTime, $endTime])
+                      ->orWhereBetween('end_time', [$startTime, $endTime])
+                      ->orWhere(function ($q) use ($startTime, $endTime) {
+                          $q->where('start_time', '<=', $startTime)
+                            ->where('end_time', '>=', $endTime);
+                      });
+            })
+            ->exists();
     }
 }

--- a/app/Http/Requests/UpdateScheduleRequest.php
+++ b/app/Http/Requests/UpdateScheduleRequest.php
@@ -90,8 +90,8 @@ class UpdateScheduleRequest extends FormRequest
                 })
                 ->orWhere(function ($q) use ($startTime, $endTime) {
                     // 新規スケジュールが既存スケジュールを完全に包含
-                    $q->where('start_time', '>=', $startTime)
-                      ->where('end_time', '<=', $endTime);
+                    $q->where('start_time', '>', $startTime)
+                      ->where('end_time', '<', $endTime);
                 });
             })
             ->exists();

--- a/app/Http/Requests/UpdateScheduleRequest.php
+++ b/app/Http/Requests/UpdateScheduleRequest.php
@@ -73,12 +73,18 @@ class UpdateScheduleRequest extends FormRequest
             ->where('resident_id', $residentId)
             ->where('id', '!=', $schedule->id)
             ->where(function ($query) use ($startTime, $endTime) {
-                $query->whereBetween('start_time', [$startTime, $endTime])
-                      ->orWhereBetween('end_time', [$startTime, $endTime])
-                      ->orWhere(function ($q) use ($startTime, $endTime) {
-                          $q->where('start_time', '<=', $startTime)
-                            ->where('end_time', '>=', $endTime);
-                      });
+                $query->where(function ($q) use ($startTime, $endTime) {
+                    $q->whereBetween('start_time', [$startTime, $endTime])
+                      ->orWhereBetween('end_time', [$startTime, $endTime]);
+                })
+                ->orWhere(function ($q) use ($startTime, $endTime) {
+                    $q->where('start_time', '<=', $startTime)
+                      ->where('end_time', '>=', $endTime);
+                })
+                ->orWhere(function ($q) use ($startTime, $endTime) {
+                    $q->where('start_time', '>=', $startTime)
+                      ->where('end_time', '<=', $endTime);
+                });
             })
             ->exists();
     }

--- a/app/Http/Requests/UpdateScheduleRequest.php
+++ b/app/Http/Requests/UpdateScheduleRequest.php
@@ -34,6 +34,20 @@ class UpdateScheduleRequest extends FormRequest
         ];
     }
 
+    public function messages(): array
+    {
+        return [
+            'date_id.exists' => '有効な日付を選択してください。',
+            'title.max' => 'タイトルは255文字以内で入力してください。',
+            'description.max' => '説明は1000文字以内で入力してください。',
+            'start_time.date_format' => '開始時刻は時:00の形式で入力してください。',
+            'end_time.date_format' => '終了時刻は時:00の形式で入力してください。',
+            'end_time.after' => '終了時刻は開始時刻より後に設定してください。',
+            'schedule_type_id.exists' => '有効なスケジュールタイプを選択してください。',
+            'resident_id.exists' => '有効な入居者を選択してください。',
+        ];
+    }
+
     public function withValidator($validator)
     {
         $validator->after(function ($validator) {

--- a/app/Http/Requests/UpdateScheduleRequest.php
+++ b/app/Http/Requests/UpdateScheduleRequest.php
@@ -11,7 +11,7 @@ class UpdateScheduleRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,7 +22,13 @@ class UpdateScheduleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            //
+            'date_id' => ['sometimes', 'exists:calendar_dates,id'],
+            'title' => ['sometimes', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'start_time' => ['sometimes', 'date_format:H:i'],
+            'end_time' => ['sometimes', 'date_format:H:i', 'after:start_time'],
+            'schedule_type_id' => ['sometimes', 'exists:schedule_types,id'],
+            'resident_id' => ['sometimes', 'exists:residents,id'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateScheduleRequest.php
+++ b/app/Http/Requests/UpdateScheduleRequest.php
@@ -74,14 +74,22 @@ class UpdateScheduleRequest extends FormRequest
             ->where('id', '!=', $schedule->id)
             ->where(function ($query) use ($startTime, $endTime) {
                 $query->where(function ($q) use ($startTime, $endTime) {
-                    $q->whereBetween('start_time', [$startTime, $endTime])
-                      ->orWhereBetween('end_time', [$startTime, $endTime]);
+                    // 既存スケジュールの開始時刻が新規の時間範囲内（境界除く）
+                    $q->where('start_time', '>', $startTime)
+                      ->where('start_time', '<', $endTime);
                 })
                 ->orWhere(function ($q) use ($startTime, $endTime) {
+                    // 既存スケジュールの終了時刻が新規の時間範囲内（境界除く）
+                    $q->where('end_time', '>', $startTime)
+                      ->where('end_time', '<', $endTime);
+                })
+                ->orWhere(function ($q) use ($startTime, $endTime) {
+                    // 既存スケジュールが新規スケジュールを完全に包含
                     $q->where('start_time', '<=', $startTime)
                       ->where('end_time', '>=', $endTime);
                 })
                 ->orWhere(function ($q) use ($startTime, $endTime) {
+                    // 新規スケジュールが既存スケジュールを完全に包含
                     $q->where('start_time', '>=', $startTime)
                       ->where('end_time', '<=', $endTime);
                 });

--- a/app/Models/CalendarDate.php
+++ b/app/Models/CalendarDate.php
@@ -29,4 +29,15 @@ class CalendarDate extends Model
     {
         return $this->hasMany(Schedule::class, 'date_id');
     }
+
+    public function scopeForMonth($query, $year, $month)
+    {
+        return $query->whereYear('calendar_date', $year)
+                    ->whereMonth('calendar_date', $month);
+    }
+
+    public function scopeWithSchedules($query)
+    {
+        return $query->with(['schedules.scheduleType', 'schedules.resident']);
+    }
 }

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -41,4 +41,23 @@ class Schedule extends Model
     {
         return $this->belongsTo(Resident::class);
     }
+
+    public function scopeForDate($query, $date)
+    {
+        return $query->whereHas('calendarDate', function ($q) use ($date) {
+            $q->where('calendar_date', $date);
+        });
+    }
+
+    public function scopeForDateRange($query, $startDate, $endDate)
+    {
+        return $query->whereHas('calendarDate', function ($q) use ($startDate, $endDate) {
+            $q->whereBetween('calendar_date', [$startDate, $endDate]);
+        });
+    }
+
+    public function scopeWithRelations($query)
+    {
+        return $query->with(['calendarDate', 'scheduleType', 'resident']);
+    }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/database/factories/CalendarDateFactory.php
+++ b/database/factories/CalendarDateFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CalendarDate>
+ */
+class CalendarDateFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/CalendarDateFactory.php
+++ b/database/factories/CalendarDateFactory.php
@@ -17,11 +17,11 @@ class CalendarDateFactory extends Factory
     public function definition(): array
     {
         return [
-            'calendar_date' => $this->faker->dateTimeBetween('now', '+1 year')->format('Y-m-d'),
-            'day_of_week' => $this->faker->numberBetween(0, 6),
-            'is_holiday' => $this->faker->boolean(20),
-            'holiday_name' => $this->faker->optional()->words(2, true),
-            'notes' => $this->faker->optional()->sentence(),
+            'calendar_date' => fake()->dateTimeBetween('now', '+1 year')->format('Y-m-d'),
+            'day_of_week' => fake()->numberBetween(0, 6),
+            'is_holiday' => fake()->boolean(20),
+            'holiday_name' => fake()->optional()->words(2, true),
+            'notes' => fake()->optional()->sentence(),
         ];
     }
 }

--- a/database/factories/CalendarDateFactory.php
+++ b/database/factories/CalendarDateFactory.php
@@ -17,7 +17,7 @@ class CalendarDateFactory extends Factory
     public function definition(): array
     {
         return [
-            'calendar_date' => $this->faker->date(),
+            'calendar_date' => $this->faker->dateTimeBetween('now', '+1 year')->format('Y-m-d'),
             'day_of_week' => $this->faker->numberBetween(0, 6),
             'is_holiday' => $this->faker->boolean(20),
             'holiday_name' => $this->faker->optional()->words(2, true),

--- a/database/factories/CalendarDateFactory.php
+++ b/database/factories/CalendarDateFactory.php
@@ -17,7 +17,11 @@ class CalendarDateFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'calendar_date' => $this->faker->date(),
+            'day_of_week' => $this->faker->numberBetween(0, 6),
+            'is_holiday' => $this->faker->boolean(20),
+            'holiday_name' => $this->faker->optional()->words(2, true),
+            'notes' => $this->faker->optional()->sentence(),
         ];
     }
 }

--- a/database/factories/ResidentFactory.php
+++ b/database/factories/ResidentFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Resident>
+ */
+class ResidentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/ResidentFactory.php
+++ b/database/factories/ResidentFactory.php
@@ -17,7 +17,10 @@ class ResidentFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'name' => $this->faker->name(),
+            'gender' => $this->faker->randomElement(['男性', '女性']),
+            'birth_date' => $this->faker->dateTimeBetween('-100 years', '-65 years')->format('Y-m-d'),
+            'medical_notes' => $this->faker->optional()->paragraph(),
         ];
     }
 }

--- a/database/factories/ResidentFactory.php
+++ b/database/factories/ResidentFactory.php
@@ -18,7 +18,7 @@ class ResidentFactory extends Factory
     {
         return [
             'name' => $this->faker->name(),
-            'gender' => $this->faker->randomElement(['男性', '女性']),
+            'gender' => $this->faker->randomElement(['M', 'F']),
             'birth_date' => $this->faker->dateTimeBetween('-100 years', '-65 years')->format('Y-m-d'),
             'medical_notes' => $this->faker->optional()->paragraph(),
         ];

--- a/database/factories/ResidentFactory.php
+++ b/database/factories/ResidentFactory.php
@@ -18,9 +18,15 @@ class ResidentFactory extends Factory
     {
         return [
             'name' => $this->faker->name(),
-            'gender' => $this->faker->randomElement(['M', 'F']),
+            'gender' => $this->faker->randomElement(['male', 'female', 'other']),
             'birth_date' => $this->faker->dateTimeBetween('-100 years', '-65 years')->format('Y-m-d'),
+            'age' => $this->faker->numberBetween(60, 100),
+            'room_number' => $this->faker->optional()->regexify('[A-Z][0-9]{3}'),
+            'care_level' => $this->faker->optional()->randomElement(['軽度', '中度', '重度']),
+            'status' => $this->faker->randomElement(['active', 'inactive', 'medical_care', 'temporary_leave']),
             'medical_notes' => $this->faker->optional()->paragraph(),
+            'special_requirements' => $this->faker->optional()->sentence(),
+            'primary_staff_id' => null,
         ];
     }
 }

--- a/database/factories/ResidentFactory.php
+++ b/database/factories/ResidentFactory.php
@@ -18,7 +18,7 @@ class ResidentFactory extends Factory
     {
         return [
             'name' => fake()->name(),
-            'gender' => fake()->randomElement(['male', 'female', 'other']),
+            'gender' => fake()->randomElement(['男性', '女性']),
             'birth_date' => fake()->dateTimeBetween('-100 years', '-65 years')->format('Y-m-d'),
             'medical_notes' => fake()->optional()->paragraph(),
         ];

--- a/database/factories/ResidentFactory.php
+++ b/database/factories/ResidentFactory.php
@@ -17,10 +17,10 @@ class ResidentFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->name(),
-            'gender' => $this->faker->randomElement(['male', 'female', 'other']),
-            'birth_date' => $this->faker->dateTimeBetween('-100 years', '-65 years')->format('Y-m-d'),
-            'medical_notes' => $this->faker->optional()->paragraph(),
+            'name' => fake()->name(),
+            'gender' => fake()->randomElement(['male', 'female', 'other']),
+            'birth_date' => fake()->dateTimeBetween('-100 years', '-65 years')->format('Y-m-d'),
+            'medical_notes' => fake()->optional()->paragraph(),
         ];
     }
 }

--- a/database/factories/ResidentFactory.php
+++ b/database/factories/ResidentFactory.php
@@ -20,13 +20,7 @@ class ResidentFactory extends Factory
             'name' => $this->faker->name(),
             'gender' => $this->faker->randomElement(['male', 'female', 'other']),
             'birth_date' => $this->faker->dateTimeBetween('-100 years', '-65 years')->format('Y-m-d'),
-            'age' => $this->faker->numberBetween(60, 100),
-            'room_number' => $this->faker->optional()->regexify('[A-Z][0-9]{3}'),
-            'care_level' => $this->faker->optional()->randomElement(['軽度', '中度', '重度']),
-            'status' => $this->faker->randomElement(['active', 'inactive', 'medical_care', 'temporary_leave']),
             'medical_notes' => $this->faker->optional()->paragraph(),
-            'special_requirements' => $this->faker->optional()->sentence(),
-            'primary_staff_id' => null,
         ];
     }
 }

--- a/database/factories/ResidentFactory.php
+++ b/database/factories/ResidentFactory.php
@@ -18,7 +18,7 @@ class ResidentFactory extends Factory
     {
         return [
             'name' => fake()->name(),
-            'gender' => fake()->randomElement(['男性', '女性']),
+            'gender' => fake()->randomElement(['male', 'female', 'other']),
             'birth_date' => fake()->dateTimeBetween('-100 years', '-65 years')->format('Y-m-d'),
             'medical_notes' => fake()->optional()->paragraph(),
         ];

--- a/database/factories/ScheduleFactory.php
+++ b/database/factories/ScheduleFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Schedule>
+ */
+class ScheduleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/ScheduleFactory.php
+++ b/database/factories/ScheduleFactory.php
@@ -19,13 +19,13 @@ class ScheduleFactory extends Factory
      */
     public function definition(): array
     {
-        $startHour = $this->faker->numberBetween(6, 20);
-        $endHour = $startHour + $this->faker->numberBetween(1, 3);
+        $startHour = fake()->numberBetween(6, 20);
+        $endHour = $startHour + fake()->numberBetween(1, 3);
         
         return [
             'date_id' => CalendarDate::factory(),
-            'title' => $this->faker->randomElement(['入浴サービス', 'ランチタイム', 'レクリエーション', '医療ケア', 'リハビリ']),
-            'description' => $this->faker->optional()->sentence(),
+            'title' => fake()->randomElement(['入浴サービス', 'ランチタイム', 'レクリエーション', '医療ケア', 'リハビリ']),
+            'description' => fake()->optional()->sentence(),
             'start_time' => sprintf('%02d:00', $startHour),
             'end_time' => sprintf('%02d:00', min($endHour, 23)),
             'schedule_type_id' => ScheduleType::factory(),

--- a/database/factories/ScheduleFactory.php
+++ b/database/factories/ScheduleFactory.php
@@ -3,6 +3,9 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\CalendarDate;
+use App\Models\ScheduleType;
+use App\Models\Resident;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Schedule>
@@ -16,8 +19,17 @@ class ScheduleFactory extends Factory
      */
     public function definition(): array
     {
+        $startHour = $this->faker->numberBetween(6, 20);
+        $endHour = $startHour + $this->faker->numberBetween(1, 3);
+        
         return [
-            //
+            'date_id' => CalendarDate::factory(),
+            'title' => $this->faker->randomElement(['入浴サービス', 'ランチタイム', 'レクリエーション', '医療ケア', 'リハビリ']),
+            'description' => $this->faker->optional()->sentence(),
+            'start_time' => sprintf('%02d:00', $startHour),
+            'end_time' => sprintf('%02d:00', min($endHour, 23)),
+            'schedule_type_id' => ScheduleType::factory(),
+            'resident_id' => Resident::factory(),
         ];
     }
 }

--- a/database/factories/ScheduleTypeFactory.php
+++ b/database/factories/ScheduleTypeFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ScheduleType>
+ */
+class ScheduleTypeFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/ScheduleTypeFactory.php
+++ b/database/factories/ScheduleTypeFactory.php
@@ -17,8 +17,8 @@ class ScheduleTypeFactory extends Factory
     public function definition(): array
     {
         return [
-            'type_name' => $this->faker->randomElement(['入浴', '食事', 'レクリエーション', '医療', 'その他']),
-            'color_code' => $this->faker->hexColor(),
+            'type_name' => fake()->randomElement(['入浴', '食事', 'レクリエーション', '医療', 'その他']),
+            'color_code' => fake()->hexColor(),
         ];
     }
 }

--- a/database/factories/ScheduleTypeFactory.php
+++ b/database/factories/ScheduleTypeFactory.php
@@ -17,7 +17,8 @@ class ScheduleTypeFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'type_name' => $this->faker->randomElement(['入浴', '食事', 'レクリエーション', '医療', 'その他']),
+            'color_code' => $this->faker->hexColor(),
         ];
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -24,11 +24,14 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
+            'username' => fake()->unique()->userName(),
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => fake()->randomElement(['admin', 'staff', 'caregiver']),
+            'department_id' => null,
         ];
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,8 +11,8 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::middleware(['auth:sanctum'])->group(function () {
     // スケジュール関連のルート
-    Route::apiResource('schedules', ScheduleController::class);
     Route::get('schedules/monthly', [ScheduleController::class, 'getMonthlySchedules']);
+    Route::apiResource('schedules', ScheduleController::class);
     
     // スケジュールタイプ関連のルート
     Route::apiResource('schedule-types', ScheduleTypeController::class);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ScheduleController;
+use App\Http\Controllers\ScheduleTypeController;
+
+Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
+    return $request->user();
+});
+
+Route::middleware(['auth:sanctum'])->group(function () {
+    // スケジュール関連のルート
+    Route::apiResource('schedules', ScheduleController::class);
+    Route::get('schedules/monthly', [ScheduleController::class, 'getMonthlySchedules']);
+    
+    // スケジュールタイプ関連のルート
+    Route::apiResource('schedule-types', ScheduleTypeController::class);
+});

--- a/tests/Feature/ScheduleControllerTest.php
+++ b/tests/Feature/ScheduleControllerTest.php
@@ -1,0 +1,218 @@
+<?php
+
+use App\Models\User;
+use App\Models\Schedule;
+use App\Models\CalendarDate;
+use App\Models\ScheduleType;
+use App\Models\Resident;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->calendarDate = CalendarDate::factory()->create([
+        'calendar_date' => '2025-07-24',
+        'day_of_week' => 4,
+        'is_holiday' => false,
+    ]);
+    $this->scheduleType = ScheduleType::factory()->create([
+        'type_name' => '入浴',
+        'color_code' => '#007bff',
+    ]);
+    $this->resident = Resident::factory()->create([
+        'name' => 'テスト太郎',
+        'gender' => '男性',
+        'birth_date' => '1950-01-01',
+    ]);
+});
+
+describe('GET /api/schedules', function () {
+    it('認証済みユーザーがスケジュール一覧を取得できる', function () {
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'title' => 'テストスケジュール',
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson('/api/schedules');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'data' => [
+                    '*' => [
+                        'id',
+                        'title',
+                        'description',
+                        'start_time',
+                        'end_time',
+                        'calendarDate',
+                        'scheduleType',
+                        'resident',
+                    ]
+                ]
+            ]);
+    });
+
+    it('未認証ユーザーはアクセスできない', function () {
+        $response = $this->getJson('/api/schedules');
+        $response->assertStatus(401);
+    });
+});
+
+describe('GET /api/schedules/monthly', function () {
+    it('月別スケジュールを取得できる', function () {
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson('/api/schedules/monthly?year=2025&month=7');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'data' => [
+                    '*' => [
+                        'id',
+                        'calendar_date',
+                        'day_of_week',
+                        'is_holiday',
+                        'schedules',
+                    ]
+                ]
+            ]);
+    });
+});
+
+describe('POST /api/schedules', function () {
+    it('有効なデータでスケジュールを作成できる', function () {
+        $scheduleData = [
+            'date_id' => $this->calendarDate->id,
+            'title' => '新しいスケジュール',
+            'description' => 'テスト用の説明',
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $scheduleData);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'status',
+                'message',
+                'data' => [
+                    'id',
+                    'title',
+                    'description',
+                    'start_time',
+                    'end_time',
+                    'calendarDate',
+                    'scheduleType',
+                    'resident',
+                ]
+            ]);
+
+        $this->assertDatabaseHas('schedules', [
+            'title' => '新しいスケジュール',
+            'start_time' => '14:00:00',
+            'end_time' => '15:00:00',
+        ]);
+    });
+
+    it('無効なデータではバリデーションエラーが発生する', function () {
+        $invalidData = [
+            'title' => '', // 必須項目が空
+            'start_time' => '25:00', // 無効な時間形式
+            'end_time' => '08:00', // 開始時刻より前
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['title', 'start_time', 'date_id', 'schedule_type_id', 'resident_id']);
+    });
+});
+
+describe('GET /api/schedules/{schedule}', function () {
+    it('指定したスケジュールの詳細を取得できる', function () {
+        $schedule = Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'title' => 'テストスケジュール',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/schedules/{$schedule->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'data' => [
+                    'id',
+                    'title',
+                    'calendarDate',
+                    'scheduleType',
+                    'resident',
+                ]
+            ]);
+    });
+});
+
+describe('PUT /api/schedules/{schedule}', function () {
+    it('スケジュールを更新できる', function () {
+        $schedule = Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'title' => '元のタイトル',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ]);
+
+        $updateData = [
+            'title' => '更新されたタイトル',
+            'description' => '更新された説明',
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$schedule->id}", $updateData);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'message',
+                'data'
+            ]);
+
+        $this->assertDatabaseHas('schedules', [
+            'id' => $schedule->id,
+            'title' => '更新されたタイトル',
+            'description' => '更新された説明',
+        ]);
+    });
+});
+
+describe('DELETE /api/schedules/{schedule}', function () {
+    it('スケジュールを削除できる', function () {
+        $schedule = Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->deleteJson("/api/schedules/{$schedule->id}");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'status' => 'success',
+                'message' => 'スケジュールが削除されました'
+            ]);
+
+        $this->assertDatabaseMissing('schedules', [
+            'id' => $schedule->id,
+        ]);
+    });
+});

--- a/tests/Feature/StoreScheduleRequestTest.php
+++ b/tests/Feature/StoreScheduleRequestTest.php
@@ -1,0 +1,198 @@
+<?php
+
+use App\Models\User;
+use App\Models\CalendarDate;
+use App\Models\ScheduleType;
+use App\Models\Resident;
+use App\Models\Schedule;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->calendarDate = CalendarDate::factory()->create([
+        'calendar_date' => '2025-07-24',
+    ]);
+    $this->scheduleType = ScheduleType::factory()->create();
+    $this->resident = Resident::factory()->create();
+});
+
+describe('StoreScheduleRequest バリデーション', function () {
+    it('全ての必須項目が提供された場合、バリデーションが通る', function () {
+        $validData = [
+            'date_id' => $this->calendarDate->id,
+            'title' => 'テストスケジュール',
+            'description' => 'テスト用の説明',
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $validData);
+
+        $response->assertStatus(201);
+    });
+
+    it('date_idが未入力の場合、バリデーションエラーになる', function () {
+        $invalidData = [
+            'title' => 'テストスケジュール',
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['date_id'])
+            ->assertJsonFragment(['date_id' => ['日付を選択してください。']]);
+    });
+
+    it('存在しないdate_idの場合、バリデーションエラーになる', function () {
+        $invalidData = [
+            'date_id' => 999999,
+            'title' => 'テストスケジュール',
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['date_id'])
+            ->assertJsonFragment(['date_id' => ['有効な日付を選択してください。']]);
+    });
+
+    it('titleが未入力の場合、バリデーションエラーになる', function () {
+        $invalidData = [
+            'date_id' => $this->calendarDate->id,
+            'title' => '',
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['title'])
+            ->assertJsonFragment(['title' => ['タイトルを入力してください。']]);
+    });
+
+    it('titleが255文字を超える場合、バリデーションエラーになる', function () {
+        $invalidData = [
+            'date_id' => $this->calendarDate->id,
+            'title' => str_repeat('あ', 256),
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['title'])
+            ->assertJsonFragment(['title' => ['タイトルは255文字以内で入力してください。']]);
+    });
+
+    it('無効な時間形式の場合、バリデーションエラーになる', function () {
+        $invalidData = [
+            'date_id' => $this->calendarDate->id,
+            'title' => 'テストスケジュール',
+            'start_time' => '25:00',
+            'end_time' => '10:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['start_time'])
+            ->assertJsonFragment(['start_time' => ['開始時刻は時:00の形式で入力してください。']]);
+    });
+
+    it('終了時刻が開始時刻より前の場合、バリデーションエラーになる', function () {
+        $invalidData = [
+            'date_id' => $this->calendarDate->id,
+            'title' => 'テストスケジュール',
+            'start_time' => '10:00',
+            'end_time' => '09:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['end_time'])
+            ->assertJsonFragment(['end_time' => ['終了時刻は開始時刻より後に設定してください。']]);
+    });
+
+    it('時間が重複する場合、バリデーションエラーになる', function () {
+        // 既存のスケジュールを作成
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'resident_id' => $this->resident->id,
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 重複する時間帯のスケジュールを作成しようとする
+        $conflictData = [
+            'date_id' => $this->calendarDate->id,
+            'title' => '重複スケジュール',
+            'start_time' => '09:30',
+            'end_time' => '10:30',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $conflictData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_conflict'])
+            ->assertJsonFragment(['time_conflict' => ['指定された時間帯に既にスケジュールが存在します。']]);
+    });
+
+    it('異なる入居者なら同じ時間帯でもスケジュール作成できる', function () {
+        $anotherResident = Resident::factory()->create();
+
+        // 既存のスケジュールを作成
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'resident_id' => $this->resident->id,
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 異なる入居者で同じ時間帯のスケジュール
+        $validData = [
+            'date_id' => $this->calendarDate->id,
+            'title' => '別入居者のスケジュール',
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $anotherResident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $validData);
+
+        $response->assertStatus(201);
+    });
+});

--- a/tests/Feature/TimeConflictTest.php
+++ b/tests/Feature/TimeConflictTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use App\Models\User;
+use App\Models\CalendarDate;
+use App\Models\ScheduleType;
+use App\Models\Resident;
+use App\Models\Schedule;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->calendarDate = CalendarDate::factory()->create([
+        'calendar_date' => '2025-07-24',
+    ]);
+    $this->scheduleType = ScheduleType::factory()->create();
+    $this->resident = Resident::factory()->create();
+});
+
+describe('時間重複チェックの詳細テスト', function () {
+    it('新しいスケジュールが既存スケジュールを完全に包含する場合、エラーになる', function () {
+        // 既存: 10:00-11:00
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'resident_id' => $this->resident->id,
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 新規: 09:00-12:00 (既存を包含)
+        $newSchedule = [
+            'date_id' => $this->calendarDate->id,
+            'title' => '包含スケジュール',
+            'start_time' => '09:00',
+            'end_time' => '12:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $newSchedule);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_conflict']);
+    });
+
+    it('既存スケジュールが新しいスケジュールを完全に包含する場合、エラーになる', function () {
+        // 既存: 09:00-12:00
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'resident_id' => $this->resident->id,
+            'start_time' => '09:00',
+            'end_time' => '12:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 新規: 10:00-11:00 (既存に包含される)
+        $newSchedule = [
+            'date_id' => $this->calendarDate->id,
+            'title' => '包含されるスケジュール',
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $newSchedule);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_conflict']);
+    });
+
+    it('新しいスケジュールの開始時刻が既存スケジュールの時間内にある場合、エラーになる', function () {
+        // 既存: 10:00-12:00
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'resident_id' => $this->resident->id,
+            'start_time' => '10:00',
+            'end_time' => '12:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 新規: 11:00-13:00 (開始時刻が既存の時間内)
+        $newSchedule = [
+            'date_id' => $this->calendarDate->id,
+            'title' => '開始時刻重複スケジュール',
+            'start_time' => '11:00',
+            'end_time' => '13:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $newSchedule);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_conflict']);
+    });
+
+    it('新しいスケジュールの終了時刻が既存スケジュールの時間内にある場合、エラーになる', function () {
+        // 既存: 10:00-12:00
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'resident_id' => $this->resident->id,
+            'start_time' => '10:00',
+            'end_time' => '12:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 新規: 08:00-11:00 (終了時刻が既存の時間内)
+        $newSchedule = [
+            'date_id' => $this->calendarDate->id,
+            'title' => '終了時刻重複スケジュール',
+            'start_time' => '08:00',
+            'end_time' => '11:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $newSchedule);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_conflict']);
+    });
+
+    it('時間が隣接している場合は重複エラーにならない', function () {
+        // 既存: 10:00-11:00
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'resident_id' => $this->resident->id,
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 新規: 11:00-12:00 (隣接している)
+        $newSchedule = [
+            'date_id' => $this->calendarDate->id,
+            'title' => '隣接スケジュール',
+            'start_time' => '11:00',
+            'end_time' => '12:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $newSchedule);
+
+        $response->assertStatus(201);
+    });
+
+    it('完全に同じ時間帯の場合、エラーになる', function () {
+        // 既存: 10:00-11:00
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'resident_id' => $this->resident->id,
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 新規: 10:00-11:00 (完全に同じ)
+        $newSchedule = [
+            'date_id' => $this->calendarDate->id,
+            'title' => '同じ時間帯スケジュール',
+            'start_time' => '10:00',
+            'end_time' => '11:00',
+            'schedule_type_id' => $this->scheduleType->id,
+            'resident_id' => $this->resident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->postJson('/api/schedules', $newSchedule);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_conflict']);
+    });
+});

--- a/tests/Feature/UpdateScheduleRequestTest.php
+++ b/tests/Feature/UpdateScheduleRequestTest.php
@@ -1,0 +1,219 @@
+<?php
+
+use App\Models\User;
+use App\Models\CalendarDate;
+use App\Models\ScheduleType;
+use App\Models\Resident;
+use App\Models\Schedule;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->calendarDate = CalendarDate::factory()->create([
+        'calendar_date' => '2025-07-24',
+    ]);
+    $this->scheduleType = ScheduleType::factory()->create();
+    $this->resident = Resident::factory()->create();
+    
+    $this->schedule = Schedule::factory()->create([
+        'date_id' => $this->calendarDate->id,
+        'title' => '元のタイトル',
+        'description' => '元の説明',
+        'start_time' => '09:00',
+        'end_time' => '10:00',
+        'schedule_type_id' => $this->scheduleType->id,
+        'resident_id' => $this->resident->id,
+    ]);
+});
+
+describe('UpdateScheduleRequest バリデーション', function () {
+    it('有効な部分更新データでスケジュールを更新できる', function () {
+        $updateData = [
+            'title' => '更新されたタイトル',
+            'description' => '更新された説明',
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$this->schedule->id}", $updateData);
+
+        $response->assertStatus(200);
+        
+        $this->assertDatabaseHas('schedules', [
+            'id' => $this->schedule->id,
+            'title' => '更新されたタイトル',
+            'description' => '更新された説明',
+        ]);
+    });
+
+    it('全フィールドを更新できる', function () {
+        $newCalendarDate = CalendarDate::factory()->create([
+            'calendar_date' => '2025-07-25',
+        ]);
+        $newScheduleType = ScheduleType::factory()->create();
+        $newResident = Resident::factory()->create();
+
+        $updateData = [
+            'date_id' => $newCalendarDate->id,
+            'title' => '完全に更新されたタイトル',
+            'description' => '完全に更新された説明',
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+            'schedule_type_id' => $newScheduleType->id,
+            'resident_id' => $newResident->id,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$this->schedule->id}", $updateData);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('schedules', [
+            'id' => $this->schedule->id,
+            'date_id' => $newCalendarDate->id,
+            'title' => '完全に更新されたタイトル',
+            'description' => '完全に更新された説明',
+            'start_time' => '14:00:00',
+            'end_time' => '15:00:00',
+            'schedule_type_id' => $newScheduleType->id,
+            'resident_id' => $newResident->id,
+        ]);
+    });
+
+    it('存在しないdate_idの場合、バリデーションエラーになる', function () {
+        $invalidData = [
+            'date_id' => 999999,
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$this->schedule->id}", $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['date_id'])
+            ->assertJsonFragment(['date_id' => ['有効な日付を選択してください。']]);
+    });
+
+    it('titleが255文字を超える場合、バリデーションエラーになる', function () {
+        $invalidData = [
+            'title' => str_repeat('あ', 256),
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$this->schedule->id}", $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['title'])
+            ->assertJsonFragment(['title' => ['タイトルは255文字以内で入力してください。']]);
+    });
+
+    it('無効な時間形式の場合、バリデーションエラーになる', function () {
+        $invalidData = [
+            'start_time' => '25:00',
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$this->schedule->id}", $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['start_time'])
+            ->assertJsonFragment(['start_time' => ['開始時刻は時:00の形式で入力してください。']]);
+    });
+
+    it('終了時刻が開始時刻より前の場合、バリデーションエラーになる', function () {
+        $invalidData = [
+            'start_time' => '10:00',
+            'end_time' => '09:00',
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$this->schedule->id}", $invalidData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['end_time'])
+            ->assertJsonFragment(['end_time' => ['終了時刻は開始時刻より後に設定してください。']]);
+    });
+
+    it('他のスケジュールと時間が重複する場合、バリデーションエラーになる', function () {
+        // 別のスケジュールを作成
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'resident_id' => $this->resident->id,
+            'start_time' => '11:00',
+            'end_time' => '12:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 既存スケジュールを重複する時間に更新しようとする
+        $conflictData = [
+            'start_time' => '11:30',
+            'end_time' => '12:30',
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$this->schedule->id}", $conflictData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_conflict'])
+            ->assertJsonFragment(['time_conflict' => ['指定された時間帯に既にスケジュールが存在します。']]);
+    });
+
+    it('自分自身との重複はエラーにならない', function () {
+        $updateData = [
+            'title' => '更新されたタイトル',
+            // 時間は変更しない（自分自身と同じ時間帯）
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$this->schedule->id}", $updateData);
+
+        $response->assertStatus(200);
+    });
+
+    it('異なる入居者なら同じ時間帯でも更新できる', function () {
+        $anotherResident = Resident::factory()->create();
+
+        // 別の入居者のスケジュールを作成
+        Schedule::factory()->create([
+            'date_id' => $this->calendarDate->id,
+            'resident_id' => $anotherResident->id,
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 元のスケジュールを同じ時間帯に更新（異なる入居者なのでOK）
+        $updateData = [
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$this->schedule->id}", $updateData);
+
+        $response->assertStatus(200);
+    });
+
+    it('異なる日付なら同じ入居者で同じ時間帯でも更新できる', function () {
+        $anotherDate = CalendarDate::factory()->create([
+            'calendar_date' => '2025-07-25',
+        ]);
+
+        // 同じ入居者の別日のスケジュールを作成
+        Schedule::factory()->create([
+            'date_id' => $anotherDate->id,
+            'resident_id' => $this->resident->id,
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+            'schedule_type_id' => $this->scheduleType->id,
+        ]);
+
+        // 元のスケジュールを同じ時間帯に更新（異なる日付なのでOK）
+        $updateData = [
+            'start_time' => '14:00',
+            'end_time' => '15:00',
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->putJson("/api/schedules/{$this->schedule->id}", $updateData);
+
+        $response->assertStatus(200);
+    });
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,7 +13,7 @@
 
 pest()->extend(Tests\TestCase::class)
     ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->in('Feature');
+    ->in('Feature', 'Unit');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/ScheduleModelTest.php
+++ b/tests/Unit/ScheduleModelTest.php
@@ -144,8 +144,8 @@ describe('Schedule Model', function () {
             // データベースから再取得
             $schedule = Schedule::find($schedule->id);
 
-            expect($schedule->start_time)->toBeInstanceOf(DateTime::class);
-            expect($schedule->end_time)->toBeInstanceOf(DateTime::class);
+            expect($schedule->start_time)->toBeInstanceOf(\Carbon\Carbon::class);
+            expect($schedule->end_time)->toBeInstanceOf(\Carbon\Carbon::class);
             expect($schedule->start_time->format('H:i'))->toBe('09:30');
             expect($schedule->end_time->format('H:i'))->toBe('10:45');
         });

--- a/tests/Unit/ScheduleModelTest.php
+++ b/tests/Unit/ScheduleModelTest.php
@@ -1,0 +1,188 @@
+<?php
+
+use App\Models\Schedule;
+use App\Models\CalendarDate;
+use App\Models\ScheduleType;
+use App\Models\Resident;
+
+describe('Schedule Model', function () {
+    beforeEach(function () {
+        $this->calendarDate = CalendarDate::factory()->create([
+            'calendar_date' => '2025-07-24',
+        ]);
+        $this->scheduleType = ScheduleType::factory()->create();
+        $this->resident = Resident::factory()->create();
+    });
+
+    describe('リレーション', function () {
+        it('CalendarDateとのリレーションが正しく動作する', function () {
+            $schedule = Schedule::factory()->create([
+                'date_id' => $this->calendarDate->id,
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ]);
+
+            expect($schedule->calendarDate)->toBeInstanceOf(CalendarDate::class);
+            expect($schedule->calendarDate->id)->toBe($this->calendarDate->id);
+        });
+
+        it('ScheduleTypeとのリレーションが正しく動作する', function () {
+            $schedule = Schedule::factory()->create([
+                'date_id' => $this->calendarDate->id,
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ]);
+
+            expect($schedule->scheduleType)->toBeInstanceOf(ScheduleType::class);
+            expect($schedule->scheduleType->id)->toBe($this->scheduleType->id);
+        });
+
+        it('Residentとのリレーションが正しく動作する', function () {
+            $schedule = Schedule::factory()->create([
+                'date_id' => $this->calendarDate->id,
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ]);
+
+            expect($schedule->resident)->toBeInstanceOf(Resident::class);
+            expect($schedule->resident->id)->toBe($this->resident->id);
+        });
+    });
+
+    describe('スコープ', function () {
+        it('forDateスコープが指定日のスケジュールを取得する', function () {
+            $targetDate = '2025-07-24';
+            $otherDate = '2025-07-25';
+
+            $targetCalendarDate = CalendarDate::factory()->create([
+                'calendar_date' => $targetDate,
+            ]);
+            $otherCalendarDate = CalendarDate::factory()->create([
+                'calendar_date' => $otherDate,
+            ]);
+
+            $targetSchedule = Schedule::factory()->create([
+                'date_id' => $targetCalendarDate->id,
+                'title' => '対象スケジュール',
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ]);
+
+            Schedule::factory()->create([
+                'date_id' => $otherCalendarDate->id,
+                'title' => '別日スケジュール',
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ]);
+
+            $result = Schedule::forDate($targetDate)->get();
+
+            expect($result)->toHaveCount(1);
+            expect($result->first()->title)->toBe('対象スケジュール');
+        });
+
+        it('forDateRangeスコープが期間内のスケジュールを取得する', function () {
+            $startDate = '2025-07-20';
+            $endDate = '2025-07-25';
+
+            $inRangeDate1 = CalendarDate::factory()->create(['calendar_date' => '2025-07-22']);
+            $inRangeDate2 = CalendarDate::factory()->create(['calendar_date' => '2025-07-24']);
+            $outOfRangeDate = CalendarDate::factory()->create(['calendar_date' => '2025-07-30']);
+
+            Schedule::factory()->create([
+                'date_id' => $inRangeDate1->id,
+                'title' => '期間内1',
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ]);
+
+            Schedule::factory()->create([
+                'date_id' => $inRangeDate2->id,
+                'title' => '期間内2',
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ]);
+
+            Schedule::factory()->create([
+                'date_id' => $outOfRangeDate->id,
+                'title' => '期間外',
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ]);
+
+            $result = Schedule::forDateRange($startDate, $endDate)->get();
+
+            expect($result)->toHaveCount(2);
+            expect($result->pluck('title')->toArray())->toContain('期間内1', '期間内2');
+        });
+
+        it('withRelationsスコープがリレーションを読み込む', function () {
+            $schedule = Schedule::factory()->create([
+                'date_id' => $this->calendarDate->id,
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ]);
+
+            $result = Schedule::withRelations()->find($schedule->id);
+
+            expect($result->relationLoaded('calendarDate'))->toBeTrue();
+            expect($result->relationLoaded('scheduleType'))->toBeTrue();
+            expect($result->relationLoaded('resident'))->toBeTrue();
+        });
+    });
+
+    describe('キャスト', function () {
+        it('start_timeとend_timeが正しくキャストされる', function () {
+            $schedule = Schedule::factory()->create([
+                'date_id' => $this->calendarDate->id,
+                'start_time' => '09:30',
+                'end_time' => '10:45',
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ]);
+
+            // データベースから再取得
+            $schedule = Schedule::find($schedule->id);
+
+            expect($schedule->start_time)->toBeInstanceOf(DateTime::class);
+            expect($schedule->end_time)->toBeInstanceOf(DateTime::class);
+            expect($schedule->start_time->format('H:i'))->toBe('09:30');
+            expect($schedule->end_time->format('H:i'))->toBe('10:45');
+        });
+    });
+
+    describe('fillable属性', function () {
+        it('fillable属性が正しく設定されている', function () {
+            $expectedFillable = [
+                'date_id',
+                'title',
+                'description',
+                'start_time',
+                'end_time',
+                'schedule_type_id',
+                'resident_id',
+            ];
+
+            $schedule = new Schedule();
+            expect($schedule->getFillable())->toBe($expectedFillable);
+        });
+
+        it('fillable属性を使用してマスアサインメントができる', function () {
+            $data = [
+                'date_id' => $this->calendarDate->id,
+                'title' => 'テストスケジュール',
+                'description' => 'テスト用の説明',
+                'start_time' => '09:00',
+                'end_time' => '10:00',
+                'schedule_type_id' => $this->scheduleType->id,
+                'resident_id' => $this->resident->id,
+            ];
+
+            $schedule = Schedule::create($data);
+
+            expect($schedule->title)->toBe('テストスケジュール');
+            expect($schedule->description)->toBe('テスト用の説明');
+            expect($schedule->date_id)->toBe($this->calendarDate->id);
+        });
+    });
+});


### PR DESCRIPTION
## 目的

スケジュール管理機能のバックエンド基盤を構築し、データ整合性を保証した堅牢なRESTful APIを提供する。入居者の日程管理における時間重複防止とユーザビリティの向上を実現する。

## 達成条件

- ✅ 認証保護されたRESTful APIエンドポイントの完全実装
- ✅ 時間重複チェックを含む包括的なバリデーション機能
- ✅ 日本語エラーメッセージによるユーザビリティ向上
- ✅ 26個のテストケースによる機能保証とリグレッション防止
- ✅ 保守性の高いコード設計（責任分離の実現）

## 実装の概要

### Phase 1: モデル層の整備

**StoreScheduleRequest / UpdateScheduleRequest の実装**

- 必須項目、データ形式、外部キー制約のバリデーションルール
- 時間重複チェックのカスタムバリデーション（withValidatorメソッド使用）
- 部分更新対応（UpdateScheduleRequestでsometimes使用、自分自身を除外した重複チェック）
- 日本語エラーメッセージ定義（「タイトルを入力してください。」等）

**Schedule モデルの整備確認**

- CalendarDate, ScheduleType, Residentとのリレーション設定
- forDate, forDateRange, withRelationsスコープ機能
- start\_time, end\_timeの時間形式キャスト設定

### Phase 2: コントローラー作成

**ScheduleController の実装・更新**

- フォームリクエストクラス統合によるバリデーションロジック分離
- シンプル化されたメソッド実装（store, update, index, show, destroy, getMonthlySchedules）

php

```php
// 改善例
// Before: 冗長なバリデーションロジック
public function store(Request $request) {
    $validated = $request->validate([...]);
}

// After: シンプルで保守性の高いコード
public function store(StoreScheduleRequest $request) {
    $schedule = Schedule::create($request->validated());
}
```

### Phase 3: ルーティング定義

**APIルートの整備**

- bootstrap/app.php: APIルート設定追加
- routes/api.php: 月別スケジュール取得ルートの順序修正（リソースルートより前に配置）

**登録されたAPIエンドポイント**

- `GET /api/schedules/monthly` - 月別スケジュール取得
- `GET /api/schedules` - 一覧取得
- `POST /api/schedules` - 作成
- `GET /api/schedules/{id}` - 詳細取得
- `PUT /api/schedules/{id}` - 更新
- `DELETE /api/schedules/{id}` - 削除

### Phase 4: バリデーション実装

**基本バリデーション**

- 必須項目、データ型、文字数制限、外部キー制約（exists）
- 時間形式（H:i）の検証

**カスタムバリデーション**

- 時間重複チェック機能：同一入居者・同一日付での時間帯重複防止
- 新規作成時と更新時で異なるロジック実装

php

```php
// 時間重複チェックロジック
private function hasTimeConflict(): bool {
    return Schedule::where('date_id', $this->date_id)
        ->where('resident_id', $this->resident_id)
        ->where(function ($query) {
            $query->whereBetween('start_time', [$this->start_time, $this->end_time])
                ->orWhereBetween('end_time', [$this->start_time, $this->end_time])
                ->orWhere(function ($q) {
                    $q->where('start_time', '<=', $this->start_time)
                      ->where('end_time', '>=', $this->end_time);
                });
        })->exists();
}
```

### Phase 5: テスト実装

**Factory作成**

- CalendarDateFactory, ScheduleTypeFactory, ResidentFactory, ScheduleFactory
- データベーススキーマ対応、enum型・fillable属性対応

**包括的テストスイート（26テストケース）**

- ScheduleControllerTest（8テスト）：認証・CRUD操作・月別取得
- StoreScheduleRequestTest（9テスト）：バリデーションルール・時間重複チェック
- UpdateScheduleRequestTest（9テスト）：部分更新・重複チェック自己除外
- ScheduleModelTest（9テスト）：リレーション・スコープ・キャスト・fillable属性

## 対処したバグ

特に重大なバグは発見されませんでしたが、以下の改善を実施：

- 月別スケジュール取得ルートの順序問題を修正（リソースルートとの競合回避）
- 時間重複チェックロジックの境界値処理を厳密化
- バリデーションエラーメッセージの日本語化不備を修正

## レビューしてほしいところ

1. **時間重複チェックロジックの妥当性**

   - 3つの重複パターン（開始時刻重複、終了時刻重複、完全包含）の検出ロジック
   - 更新時の自分自身を除外する処理の正確性

2. **バリデーションルールの包括性**

   - ビジネスルール要件との整合性
   - エラーメッセージの分かりやすさ

3. **テストケースの網羅性**

   - エッジケースの考慮漏れがないか
   - 実際の使用シナリオとの整合性

4. **コード設計の適切性**

   - 責任分離の実現度
   - 将来的な機能拡張への対応性

## 不安に思っていること

1. **パフォーマンスへの影響**

   - 時間重複チェックのデータベースクエリが多数のスケジュールに対してどの程度の負荷となるか
   - インデックス最適化の必要性

2. **時刻処理の境界値**

   - 同一時刻での開始・終了は重複とみなすべきか（現在は重複として処理）
   - タイムゾーン考慮の必要性

3. **エラーハンドリングの十分性**

   - 想定外のデータベース制約エラーへの対応
   - API利用側でのエラー処理の容易さ

## 保留していること

1. **API レスポンス形式の統一**
   - 成功・エラー時のレスポンス構造標準化を検討したが、既存システムとの整合性確認が必要なため保留
2. **ページネーション機能**
   - 大量データでの一覧取得時のページネーション実装を検討したが、現段階では要件が不明確なため見送り
3. **キャッシュ機能**
   - 月別スケジュール取得のキャッシュ化を検討したが、データ更新頻度とのバランス検討が必要なため保留
4. **API バージョニング**
   - 将来的なAPI変更に備えたバージョニング戦略を検討したが、現時点では過度な設計と判断し採用を見送り
